### PR TITLE
Remove ansible_local, add easy-install to vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,18 +14,7 @@ Vagrant.configure(2) do |config|
     vb.memory = "1024"
   end
 
-  # hack to go around https://github.com/mitchellh/vagrant/issues/6793
-  config.vm.provision :shell, inline: <<-SCRIPT
-    GALAXY=/usr/local/bin/ansible-galaxy
-    echo '#!/usr/bin/env bash
-    /usr/bin/ansible-galaxy "$@"
-    exit 0
-    ' | sudo tee $GALAXY
-    sudo chmod 0755 $GALAXY
-  SCRIPT
-
-  config.vm.provision "ansible_local" do |ansible|
-      ansible.install        = true
+  config.vm.provision "ansible" do |ansible|
       ansible.playbook       = "setup.yml"
   end
 end

--- a/setup.yml
+++ b/setup.yml
@@ -14,6 +14,8 @@
       become: yes
       apt: name={{item}} state=installed
       with_items:
+           # easy_install which will be sued to install pip
+           - python-setuptools
            - libpython3.4-dev
            # not strictly necessary for the project as it runs on 3.4
            - libpython2.7-dev


### PR DESCRIPTION
ansible_local required a trick which might not
work depending on the host setup. Not worth it. The new file requires local
ansible, possibly in a new version. Tested on 2.1

Adding python-setuptools gives easy-install, not sure how this was missed before.
